### PR TITLE
Opencv core-dump fix

### DIFF
--- a/sdk/opencv/cap_axis_vdo.cpp
+++ b/sdk/opencv/cap_axis_vdo.cpp
@@ -290,7 +290,7 @@ VdoCapture::convert_nv12_to_rgb3()
 bool VdoCapture::retrieveFrame(int, OutputArray dst)
 {
     g_autoptr(GError) error = NULL;
-    
+
     // This should be rewritten by saving metadata at the end of the frame.
     // However this lacks VDO support.
     if(auto nbuffers = buffers.size())
@@ -333,9 +333,7 @@ bool VdoCapture::retrieveFrame(int, OutputArray dst)
 
     while(!vdo_buffer)
     {
-
         VdoBuffer* buffer = vdo_stream_get_buffer(vdo_stream, &error);
-
         VdoFrame*  frame  = vdo_buffer_get_frame(buffer);
 
         if(!frame)
@@ -355,7 +353,7 @@ bool VdoCapture::retrieveFrame(int, OutputArray dst)
         // Success!
         vdo_buffer = buffer;
     }
-    std::cout << "receive frame Suspicious C" << std::endl;
+
     if(!vdo_buffer_get_data(vdo_buffer))
         throw std::runtime_error("No Data");
 
@@ -413,7 +411,7 @@ bool VdoCapture::create()
     vdo_map_set_uint32(vdo_prop, "buffer.strategy", VDO_BUFFER_STRATEGY_INFINITE);
     vdo_map_set_uint16(vdo_prop, "timestamp.type", VDO_TIMESTAMP_MONO_SERVER);
 
-    vdo_stream = vdo_stream_new(vdo_prop, nullptr, &error);    
+    vdo_stream = vdo_stream_new(vdo_prop, nullptr, &error);
     if(!vdo_stream)
         std::cout << "Failed to initialize vdo stream" << std::endl;
         return false;

--- a/sdk/opencv/cap_axis_vdo.cpp
+++ b/sdk/opencv/cap_axis_vdo.cpp
@@ -289,25 +289,21 @@ VdoCapture::convert_nv12_to_rgb3()
 
 bool VdoCapture::retrieveFrame(int, OutputArray dst)
 {
-    std::cout << "I am in retriveFrame" << std::endl;
     g_autoptr(GError) error = NULL;
     
     // This should be rewritten by saving metadata at the end of the frame.
     // However this lacks VDO support.
     if(auto nbuffers = buffers.size())
     {
-        std::cout << "receive frame Step A" << std::endl;
         auto& mat = dst.getMatRef();
-        std::cout << "receive frame Step B" << std::endl;
+
         // Well-behaved clients will return VdoBuffers facilitating reuse!
         auto it = buffers.find(mat.data);
-        std::cout << "receive frame Step C" << std::endl;
+
         // Out of VdoBuffers -> Reuse the oldest one
         if ((it == buffers.cend()) && (nbuffers >= max_buffers))
         {
-            std::cout << "receive frame Step D" << std::endl;
             using pair = decltype(buffers)::value_type;
-            std::cout << "receive frame Step E" << std::endl;
             it = std::min_element(buffers.begin(), buffers.end(),
             [] (const pair& lhs, const pair& rhs)
             {
@@ -316,7 +312,7 @@ bool VdoCapture::retrieveFrame(int, OutputArray dst)
                 return vdo_frame_get_sequence_nbr(lbuf) < vdo_frame_get_sequence_nbr(rbuf);
             });
         }
-        std::cout << "receive frame Step F" << std::endl;
+
         if(it != buffers.cend())
         {
             VdoBuffer* buffer = it->second;
@@ -334,14 +330,14 @@ bool VdoCapture::retrieveFrame(int, OutputArray dst)
     }
 
     uint64_t grabbed_us = uint64_t(grabbed_ts.tv_sec) * 1000000u + (grabbed_ts.tv_nsec / 1000u);
-    std::cout << "receive frame Suspicious A" << std::endl;
+
     while(!vdo_buffer)
     {
-        std::cout << "receive frame Suspicious B" << std::endl;
+
         VdoBuffer* buffer = vdo_stream_get_buffer(vdo_stream, &error);
-        std::cout << "receive frame Suspicious B and half " << buffer << std::endl;
+
         VdoFrame*  frame  = vdo_buffer_get_frame(buffer);
-        std::cout << "receive frame Suspicious C " << buffer << " " << frame << std::endl;
+
         if(!frame)
             throw std::runtime_error("No Frame");
 

--- a/sdk/opencv/cap_axis_vdo.cpp
+++ b/sdk/opencv/cap_axis_vdo.cpp
@@ -218,14 +218,15 @@ double VdoCapture::getProperty(int property) const
 
 bool VdoCapture::grabFrame()
 {
+    std::cout << "I am in grab frame" << std::endl;
     g_autoptr(GError) error = NULL;
-
+    std::cout << "grabframe Step A" << std::endl;
     if(!vdo_stream)
         create();
-
+    std::cout << "grabframe Step B" << std::endl;
     vdo_buffer = nullptr;
     current_size = capture_size;
-
+    std::cout << "grabframe Step C" << std::endl;
     if(clock_gettime(CLOCK_MONOTONIC, &grabbed_ts) < 0)
         throw std::runtime_error("Clock Monotonic failed");
 
@@ -288,21 +289,25 @@ VdoCapture::convert_nv12_to_rgb3()
 
 bool VdoCapture::retrieveFrame(int, OutputArray dst)
 {
+    std::cout << "I am in retriveFrame" << std::endl;
     g_autoptr(GError) error = NULL;
-
+    
     // This should be rewritten by saving metadata at the end of the frame.
     // However this lacks VDO support.
     if(auto nbuffers = buffers.size())
     {
+        std::cout << "receive frame Step A" << std::endl;
         auto& mat = dst.getMatRef();
-
+        std::cout << "receive frame Step B" << std::endl;
         // Well-behaved clients will return VdoBuffers facilitating reuse!
         auto it = buffers.find(mat.data);
-
+        std::cout << "receive frame Step C" << std::endl;
         // Out of VdoBuffers -> Reuse the oldest one
         if ((it == buffers.cend()) && (nbuffers >= max_buffers))
         {
+            std::cout << "receive frame Step D" << std::endl;
             using pair = decltype(buffers)::value_type;
+            std::cout << "receive frame Step E" << std::endl;
             it = std::min_element(buffers.begin(), buffers.end(),
             [] (const pair& lhs, const pair& rhs)
             {
@@ -311,7 +316,7 @@ bool VdoCapture::retrieveFrame(int, OutputArray dst)
                 return vdo_frame_get_sequence_nbr(lbuf) < vdo_frame_get_sequence_nbr(rbuf);
             });
         }
-
+        std::cout << "receive frame Step F" << std::endl;
         if(it != buffers.cend())
         {
             VdoBuffer* buffer = it->second;
@@ -329,12 +334,13 @@ bool VdoCapture::retrieveFrame(int, OutputArray dst)
     }
 
     uint64_t grabbed_us = uint64_t(grabbed_ts.tv_sec) * 1000000u + (grabbed_ts.tv_nsec / 1000u);
-
+    std::cout << "receive frame Suspicious A" << std::endl;
     while(!vdo_buffer)
     {
+        std::cout << "receive frame Suspicious B" << std::endl;
         VdoBuffer* buffer = vdo_stream_get_buffer(vdo_stream, &error);
         VdoFrame*  frame  = vdo_buffer_get_frame(buffer);
-
+        std::cout << "receive frame Suspicious C " << buffer << " " << frame << std::endl;
         if(!frame)
             throw std::runtime_error("No Frame");
 
@@ -352,7 +358,7 @@ bool VdoCapture::retrieveFrame(int, OutputArray dst)
         // Success!
         vdo_buffer = buffer;
     }
-
+    std::cout << "receive frame Suspicious C" << std::endl;
     if(!vdo_buffer_get_data(vdo_buffer))
         throw std::runtime_error("No Data");
 

--- a/sdk/opencv/cap_axis_vdo.cpp
+++ b/sdk/opencv/cap_axis_vdo.cpp
@@ -218,15 +218,15 @@ double VdoCapture::getProperty(int property) const
 
 bool VdoCapture::grabFrame()
 {
-    std::cout << "I am in grab frame" << std::endl;
+
     g_autoptr(GError) error = NULL;
-    std::cout << "grabframe Step A" << std::endl;
+
     if(!vdo_stream)
         create();
-    std::cout << "grabframe Step B" << std::endl;
+    if(!vdo_stream)
+        return false;
     vdo_buffer = nullptr;
     current_size = capture_size;
-    std::cout << "grabframe Step C" << std::endl;
     if(clock_gettime(CLOCK_MONOTONIC, &grabbed_ts) < 0)
         throw std::runtime_error("Clock Monotonic failed");
 
@@ -417,9 +417,10 @@ bool VdoCapture::create()
     vdo_map_set_uint32(vdo_prop, "buffer.strategy", VDO_BUFFER_STRATEGY_INFINITE);
     vdo_map_set_uint16(vdo_prop, "timestamp.type", VDO_TIMESTAMP_MONO_SERVER);
 
-    vdo_stream = vdo_stream_new(vdo_prop, nullptr, &error);
+    vdo_stream = vdo_stream_new(vdo_prop, nullptr, &error);    
     if(!vdo_stream)
-        throw std::runtime_error(error->message);
+        std::cout << "Failed to initialize vdo stream" << std::endl;
+        return false;
 
     // 1) 'settings' contains our request + default parameters
     if(g_autoptr(VdoMap) prop = vdo_stream_get_settings(vdo_stream, nullptr))

--- a/sdk/opencv/cap_axis_vdo.cpp
+++ b/sdk/opencv/cap_axis_vdo.cpp
@@ -339,7 +339,7 @@ bool VdoCapture::retrieveFrame(int, OutputArray dst)
     {
         std::cout << "receive frame Suspicious B" << std::endl;
         VdoBuffer* buffer = vdo_stream_get_buffer(vdo_stream, &error);
-        std::cout << "receive frame Suspicious B and half " << buffer << " " << frame << std::endl;
+        std::cout << "receive frame Suspicious B and half " << buffer << std::endl;
         VdoFrame*  frame  = vdo_buffer_get_frame(buffer);
         std::cout << "receive frame Suspicious C " << buffer << " " << frame << std::endl;
         if(!frame)

--- a/sdk/opencv/cap_axis_vdo.cpp
+++ b/sdk/opencv/cap_axis_vdo.cpp
@@ -218,7 +218,6 @@ double VdoCapture::getProperty(int property) const
 
 bool VdoCapture::grabFrame()
 {
-
     g_autoptr(GError) error = NULL;
 
     if(!vdo_stream)

--- a/sdk/opencv/cap_axis_vdo.cpp
+++ b/sdk/opencv/cap_axis_vdo.cpp
@@ -339,6 +339,7 @@ bool VdoCapture::retrieveFrame(int, OutputArray dst)
     {
         std::cout << "receive frame Suspicious B" << std::endl;
         VdoBuffer* buffer = vdo_stream_get_buffer(vdo_stream, &error);
+        std::cout << "receive frame Suspicious B and half " << buffer << " " << frame << std::endl;
         VdoFrame*  frame  = vdo_buffer_get_frame(buffer);
         std::cout << "receive frame Suspicious C " << buffer << " " << frame << std::endl;
         if(!frame)


### PR DESCRIPTION
### Describe your changes
This fixes the coredump that is caused by the vdo lib mismatch. 
Now when calling cap.grab() in python, it will return false, _ if there was a problem connecting to vdo, instead of crashing.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
