### PR TITLE
Fix dependencies for python module sqlite3

### DIFF
--- a/sdk/Dockerfile.aarch64
+++ b/sdk/Dockerfile.aarch64
@@ -201,6 +201,7 @@ RUN apt-get install --reinstall --download-only -o=dir::cache=$BUILD_ROOT/python
     zlib1g-dev:$UBUNTU_ARCH \
     libffi-dev:$UBUNTU_ARCH \
     libssl-dev:$UBUNTU_ARCH \
+    libsqlite3-dev:$UBUNTU_ARCH \
     libreadline6-dev:$UBUNTU_ARCH
 WORKDIR $TARGET_ROOT
 RUN for f in $BUILD_ROOT/python_deps/archives/*.deb; do dpkg -x $f $TARGET_ROOT; done
@@ -211,7 +212,7 @@ EOF
 
 # Copy selected libs we need for python compilation
 WORKDIR $TARGET_ROOT/usr/lib/$TARGET_TOOLCHAIN/
-RUN cp -R libffi* libreadline* libssl* libz* libcrypt* libncurses* libunistring* libidn* libtinfo* libgpm* libbz2* ..
+RUN cp -R libffi* libreadline* libssl* libz* libcrypt* libncurses* libunistring* libidn* libtinfo* libgpm* libbz2* libsqlite3* ..
 RUN <<EOF
 cp -r $TARGET_ROOT/usr/include/$TARGET_TOOLCHAIN/* $TARGET_ROOT/usr/include/
 rm -r $TARGET_ROOT/usr/include/$TARGET_TOOLCHAIN
@@ -236,7 +237,8 @@ RUN ./configure --host=$TARGET_TOOLCHAIN --with-openssl=$TARGET_ROOT/usr \
     --build=x86_64-linux-gnu --prefix=$TARGET_ROOT/usr \
     --enable-shared --disable-ipv6 \
     ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no \
-    --with-lto --enable-optimizations
+    --with-lto --enable-optimizations \
+    --enable-loadable-sqlite-extensions
 RUN make HOSTPYTHON=/usr/bin/python3 -j $PYTHON_BUILD_CORES CROSS_COMPILE=$TARGET_TOOLCHAIN CROSS_COMPILE_TARGET=yes
 RUN make altinstall HOSTPYTHON=python3 CROSS_COMPILE=$TARGET_TOOLCHAIN CROSS_COMPILE_TARGET=yes prefix=$TARGET_ROOT/usr
 WORKDIR $TARGET_ROOT/usr/bin

--- a/sdk/Dockerfile.armv7hf
+++ b/sdk/Dockerfile.armv7hf
@@ -201,6 +201,7 @@ RUN apt-get install --reinstall --download-only -o=dir::cache=$BUILD_ROOT/python
     zlib1g-dev:$UBUNTU_ARCH \
     libffi-dev:$UBUNTU_ARCH \
     libssl-dev:$UBUNTU_ARCH \
+    libsqlite3-dev:$UBUNTU_ARCH \
     libreadline6-dev:$UBUNTU_ARCH
 WORKDIR $TARGET_ROOT
 RUN for f in $BUILD_ROOT/python_deps/archives/*.deb; do dpkg -x $f $TARGET_ROOT; done
@@ -211,7 +212,7 @@ EOF
 
 # Copy selected libs we need for python compilation
 WORKDIR $TARGET_ROOT/usr/lib/$TARGET_TOOLCHAIN/
-RUN cp -R libffi* libreadline* libssl* libz* libcrypt* libncurses* libunistring* libidn* libtinfo* libgpm* libbz2* ..
+RUN cp -R libffi* libreadline* libssl* libz* libcrypt* libncurses* libunistring* libidn* libtinfo* libgpm* libbz2* libsqlite3* ..
 RUN <<EOF
 cp -r $TARGET_ROOT/usr/include/$TARGET_TOOLCHAIN/* $TARGET_ROOT/usr/include/
 rm -r $TARGET_ROOT/usr/include/$TARGET_TOOLCHAIN
@@ -236,7 +237,8 @@ RUN ./configure --host=$TARGET_TOOLCHAIN --with-openssl=$TARGET_ROOT/usr \
     --build=x86_64-linux-gnu --prefix=$TARGET_ROOT/usr \
     --enable-shared --disable-ipv6 \
     ac_cv_file__dev_ptmx=no ac_cv_file__dev_ptc=no \
-    --with-lto --enable-optimizations
+    --with-lto --enable-optimizations \
+    --enable-loadable-sqlite-extensions
 RUN make HOSTPYTHON=/usr/bin/python3 -j $PYTHON_BUILD_CORES CROSS_COMPILE=$TARGET_TOOLCHAIN CROSS_COMPILE_TARGET=yes
 RUN make altinstall HOSTPYTHON=python3 CROSS_COMPILE=$TARGET_TOOLCHAIN CROSS_COMPILE_TARGET=yes prefix=$TARGET_ROOT/usr
 WORKDIR $TARGET_ROOT/usr/bin


### PR DESCRIPTION
I noted this problem in issue https://github.com/AxisCommunications/acap-computer-vision-sdk/issues/32, see that for more background info.

The optional module sqlite3 was not built when building the SDK due to missing dependencies. This prevented use of multiple common python packages like e.g. IPython.

For future reference, note that there are still more optional modules that are not built:
```
The necessary bits to build these optional modules were not found:
_curses_panel         _dbm                  _gdbm              
_lzma                 _tkinter              _uuid              
To find the necessary bits, look in setup.py in detect_modules() for the module's name.
```
This can be seen by running this command:
```
docker buildx build . -f Dockerfile.armv7hf --target build-python -t sdk-homebrew:build-python-3
docker run --rm -it --workdir /build-root/Python-3.8.8 sdk-homebrew:build-python-cross-3 make
```

### Describe your changes

This commit adds the dependencies and makes sure that the module is built.

This commit increases the size of the runtime image from `945MB` to `947MB`.

### Issue ticket number and link

- Fixes [#(issue 32)](https://github.com/AxisCommunications/acap-computer-vision-sdk/issues/32)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
